### PR TITLE
✨ Feat : JDK 21 with Jacoco (#18)

### DIFF
--- a/.github/workflows/gradle-test-main.yml
+++ b/.github/workflows/gradle-test-main.yml
@@ -15,10 +15,18 @@ jobs:
             -   uses: actions/setup-java@v4
                 with:
                     distribution: 'liberica'
-                    java-version: '17'
+                    java-version: '21'
 
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
 
             -   name: Run gradlew clean test on main
-                run: ./gradlew clean test
+                run: ./gradlew clean test --warning-mode=all
+
+            -   name: Upload test coverage to Codecov.io
+                uses: codecov/codecov-action@v4
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
+                    slug: spring-templates/spring-concurrency-thread
+                    fail_ci_if_error: true 
+                    verbose: true 

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -15,7 +15,7 @@ jobs:
             -   uses: actions/setup-java@v4
                 with:
                     distribution: 'liberica'
-                    java-version: '17'
+                    java-version: '21'
 
             -   name: Cache Gradle packages
                 uses: actions/cache@v4
@@ -29,4 +29,13 @@ jobs:
                 run: chmod +x gradlew
 
             -   name: Run gradlew test
-                run: ./gradlew test
+                run: ./gradlew test --warning-mode=all
+
+            -   name: Upload test coverage to Codecov.io
+                uses: codecov/codecov-action@v4
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
+                    slug: spring-templates/spring-concurrency-thread
+                    fail_ci_if_error: true 
+                    verbose: true 
+                    flags: unittests

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -15,7 +15,7 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/com/thread/concurrency/SpringThreadConcurrencyApplicationTests.java
+++ b/src/test/java/com/thread/concurrency/SpringThreadConcurrencyApplicationTests.java
@@ -2,12 +2,14 @@ package com.thread.concurrency;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @SpringBootTest
 class SpringThreadConcurrencyApplicationTests {
 
     @Test
     void contextLoads() {
+        assertDoesNotThrow(() -> SpringThreadConcurrencyApplication.main(new String[]{}));
     }
 
 }


### PR DESCRIPTION
* ✨ Feat : `.gitmessage`

- import from `spring-templates/java-lotto`
- 백엔드 개발 간 자주 사용될 것으로 예상되는 내용으로 수정

* 🚚 Chore : Spring 프로젝트 초기화

- Java/Spring Boot
- BellSoft Liberica JDK 17
- Spring Web
- [spring initializr](https://start.spring.io/#!type=gradle-project-kotlin&language=java&platformVersion=3.2.4&packaging=jar&jvmVersion=17&groupId=com.concurrency&artifactId=thread&name=spring-concurrency-thread&description=Examples%20of%20Java%20Thread%20Concurrency%20in%20Spring%20Framework&packageName=com.concurrency.thread&dependencies=web)

* 🐛 Fix : 경고 억제를 위한 빌드 설정

- gradle deprecated usage
- jvm CDS

* ✨ Feat : Build Optimizing

- enable build caching
- enable CDS while execution

* 🚚 Chore : GitHub Actions 통합 테스트

* 🐛 Fix : 유효하지 않은 캐시키 이슈

- `.gradle/caches`에 의존성 나열

* 🐛 Fix : remove redundancy

- GitHub Actions의 자체 캐싱 활용

* ✨ Feat : test 정책 변경

- `main` 브랜치만 clean test 수행

* 🐛 Fix : 캐싱 기능

* 🐛 Fix : `main` 이외 브랜치 캐싱

* 📝 Docs : PR template

* 🐛 Fix : `.gitmessage` format 추가

* 🎨 Style : polishing

* 🚚 Chore : simplify dependency

* ✨ Feat : JDK 21 with Jacoco (#15)

* 🚚 Chore : 프로젝트 초기화 (#9)

* ✨ Feat : `.gitmessage`

- import from `spring-templates/java-lotto`
- 백엔드 개발 간 자주 사용될 것으로 예상되는 내용으로 수정

* 🚚 Chore : Spring 프로젝트 초기화

- Java/Spring Boot
- BellSoft Liberica JDK 17
- Spring Web
- [spring initializr](https://start.spring.io/#!type=gradle-project-kotlin&language=java&platformVersion=3.2.4&packaging=jar&jvmVersion=17&groupId=com.concurrency&artifactId=thread&name=spring-concurrency-thread&description=Examples%20of%20Java%20Thread%20Concurrency%20in%20Spring%20Framework&packageName=com.concurrency.thread&dependencies=web)

* 🐛 Fix : 경고 억제를 위한 빌드 설정

- gradle deprecated usage
- jvm CDS

* ✨ Feat : Build Optimizing

- enable build caching
- enable CDS while execution

* 🚚 Chore : GitHub Actions 통합 테스트

* 🐛 Fix : 유효하지 않은 캐시키 이슈

- `.gradle/caches`에 의존성 나열

* 🐛 Fix : remove redundancy

- GitHub Actions의 자체 캐싱 활용

* ✨ Feat : test 정책 변경

- `main` 브랜치만 clean test 수행

* 🐛 Fix : 캐싱 기능

* 🐛 Fix : `main` 이외 브랜치 캐싱

* 📝 Docs : PR template

* 🐛 Fix : `.gitmessage` format 추가

* 🎨 Style : polishing

* 🚚 Chore : simplify dependency

* ✨ Feat : JDK 21 with Jacoco

* 🔧 Modify : codecov-action 테스트

[codecov-action](https://github.com/codecov/codecov-action)

## 개요

<!-- 이 PR은 무엇을 하는지 간단히 설명해주세요.
- 새로운 로그인 기능 추가
-->

## 변경 사항

<!-- 이 PR로 인해 어떤 것이 변경되는지 나열해주세요.
- [x] 🐛 Fix : 오류 수정
- [x] ✨ Feat : 새로운 기능
- [x] 🔧 Modify : 위치 변경
- [x] 🤖 Refactor : 코드 리팩토링
- [x] ✅ Test : 테스트 코드 추가
- [x] 💡 Comment : 필요한 주석 추가 및 변경
- [x] 🚚 Chore : 환경설정 변경
- [x] 🎨 Style : 의미 없는 코드 형식 수정
- [x] 🔥 Remove : 삭제
- [x] 📝 Docs : 문서 수정
-->

## 추가 정보

<!-- 이 PR에 대해 필요한 후속 작업이 있다면 추가해주세요.
- [ ] 로그인 페이지 추가 필요
- [ ] 로그인 API 연결 필요
-->

### 관련 이슈

<!--
문제를 해결한다면 Fix 또는 Resolve
일반적으로는 Closes #123
-->


